### PR TITLE
Fix/add tasks

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Genre;
+use App\Models\User;
+use App\Models\Role;
+use App\Models\Vote;
+use App\Models\Complete;
+use App\Models\Task;
+use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\HasApiTokens;
+use \Symfony\Component\HttpFoundation\Response;
+
+class TaskController extends Controller
+{
+
+   // 管理者が新しいタスクを追加する
+   public function add_new_task(Request $request)
+   {
+
+        // $role = (1,管理者),(2,一般ユーザ)
+        // 一般ユーザは追加できない
+        $general_role_id = 2;
+        if ($request->user()->role_id == $general_role_id) {
+            return response()->json('You are not allowed.', Response::HTTP_BAD_REQUEST);
+        }
+
+        $is_task_inserted = Task::create(
+            [
+                'name' => $request->name,
+                'grade_id' => $request->grade_id,
+                'genre_id' => $request->genre_id,
+                'description' => $request->description,
+                'is_positive_check' => $request->is_positive_check,
+            ]
+        );
+        if ($is_task_inserted) {
+            return response()->json('Accepted', Response::HTTP_OK);
+        } else {
+            return response()->json('Server Error', Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+   }
+
+    // タスクの一部を変更する
+   public function update_task(Request $request)
+   {    
+        // $role = (1,管理者),(2,一般ユーザ)
+        // 一般ユーザは追加できない
+        $general_role_id = 2;
+        if ($request->user()->role_id == $general_role_id) {
+            return response()->json('You are not allowed.', Response::HTTP_BAD_REQUEST);
+        }
+
+        // リクエストに与えられないカラムがあればnull値に変更する
+        // nullに変更するのは "" だと空文字で更新される心配がある。
+        // foreach ($request as $key => $value) {
+        //     if ($value->isEmpty()){
+        //         $value = null;
+        //     }
+        // }
+
+        $is_task_changed = Task::update(
+            [
+                'name' => $request->name,
+                'grade_id' => $request->grade_id,
+                'genre_id' => $request->genre_id,
+                'description' => $request->description,
+                'is_positive_check' => $request->is_positive_check,
+            ]
+        )->where('id','=',$request->id);
+
+        if ($is_task_changed) {
+            return response()->json('Accepted', Response::HTTP_OK);
+        } else {
+            return response()->json('Server Error', Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+   }
+}

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -61,15 +61,20 @@ class TaskController extends Controller
         //     }
         // }
 
-        $is_task_changed = Task::update(
-            [
-                'name' => $request->name,
-                'grade_id' => $request->grade_id,
-                'genre_id' => $request->genre_id,
-                'description' => $request->description,
-                'is_positive_check' => $request->is_positive_check,
-            ]
-        )->where('id','=',$request->id);
+        // $is_task_changed = DB::raw('UPDATE TABLE SET NAME = (CASE WHEN :newName IS NOT NULL THEN :newName ELSE NAME END),
+        //     AGE  = (CASE WHEN :newAge IS NOT NULL THEN :newAge ELSE AGE END),
+        //     DESCRIPTION  = (CASE WHEN :newDescription IS NOT NULL THEN :newDescription ELSE DESCRIPTION END) WHERE ID = :id;')
+        $is_task_changed = Task::where('id','=',$request->id)
+            ->first()
+            ->update(
+                [
+                    'name' => $request->name,
+                    'grade_id' => $request->grade_id,
+                    'genre_id' => $request->genre_id,
+                    'description' => $request->description,
+                    'is_positive_check' => $request->is_positive_check,
+                ]
+            );
 
         if ($is_task_changed) {
             return response()->json('Accepted', Response::HTTP_OK);

--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -27,7 +27,7 @@ class TaskController extends Controller
             return response()->json('You are not allowed.', Response::HTTP_BAD_REQUEST);
         }
 
-        $is_task_inserted = Task::create(
+        Task::create(
             [
                 'name' => $request->name,
                 'grade_id' => $request->grade_id,
@@ -36,11 +36,7 @@ class TaskController extends Controller
                 'is_positive_check' => $request->is_positive_check,
             ]
         );
-        if ($is_task_inserted) {
-            return response()->json('Accepted', Response::HTTP_OK);
-        } else {
-            return response()->json('Server Error', Response::HTTP_INTERNAL_SERVER_ERROR);
-        }
+        return response()->json('Accepted', Response::HTTP_OK);
    }
 
     // タスクの一部を変更する

--- a/app/Models/Task.php
+++ b/app/Models/Task.php
@@ -8,4 +8,16 @@ use Illuminate\Database\Eloquent\Model;
 class Task extends Model
 {
     use HasFactory;
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name',
+        'grade_id',
+        'genre_id',
+        'description',
+        'is_positive_check'
+    ];
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\UserController;
+use App\Http\Controllers\TaskController;
 use App\Http\Controllers\LotteryController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\RegisterController;
@@ -29,16 +30,11 @@ Route::post('/login', [LoginController::class, 'login']);
 // リモ達(api/user)
 Route::middleware('auth:sanctum')->get('/user',[UserController::class, 'get_user_info']);
 Route::middleware('auth:sanctum')->post('/user', [UserController::class, 'post_completed_task']);
-// Route::put($uri, $callback);
-// Route::patch($uri, $callback);
-// Route::delete($uri, $callback);
-// Route::options($uri, $callback);
 
+// タスク追加(api/task)
+Route::middleware('auth:sanctum')->post('/task',[TaskController::class, 'add_new_task']);
+Route::middleware('auth:sanctum')->put('/task', [TaskController::class, 'update_task']);
 
 // 宝くじ(api/lottery)
 Route::middleware('auth:sanctum')->get('/lottery', [LotteryController::class, 'get_winner']);
 Route::middleware('auth:sanctum')->post('/lottery', [LotteryController::class, 'post_voting']);
-// Route::put($uri, $callback);
-// Route::patch($uri, $callback);
-// Route::delete($uri, $callback);
-// Route::options($uri, $callback);

--- a/tests/Feature/UserControllerTest.php
+++ b/tests/Feature/UserControllerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class UserControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function test_get_user_info()
+    {
+        
+        // ログインする
+        
+        // ログイン情報を利用してgetリクエスト飛ばす
+        $response = $this->get(route('users.get_user_info'));
+
+        // Taskテーブルのレコード数
+        // $tasks_num = 
+
+        // レスポンスの検証
+        $response->assertOk() # ステータスコードが 200
+            ->assertJsonCount(1 /* $tasks_num */) # レスポンスの配列の件数がtasksテーブルのレコード数
+            // レスポンスで返ってきたものが全て一致する
+            ->assertJsonFragment([ # レスポンスJSON に以下の値を含む
+                'email' => 'user1@example.com',
+            ]);
+    }
+
+    public function post_completed_task()
+    {
+        
+        // ログインする
+        
+        // ログイン情報を利用してgetリクエスト飛ばす
+
+        $data1 = [ # 登録用のデータ
+            'task_id' => 1,
+            'is_task_checked' => FALSE
+        ];
+        
+        $data2 = [ # 登録用のデータ
+            'task_id' => 1,
+            'is_task_checked' => TRUE
+        ];
+
+
+        // 投票する前
+        // まだチェックしてなくてチェックしようとする
+        $response1 = $this->post(route('users.get_user_info'), $data1);
+        $response1->assertOk();
+
+        // チェックしていてチェックしようとする
+        $response2 = $this->post(route('users.get_user_info'), $data1);
+        $response2->assertOk();
+        
+        // チェックしていて外そうとする
+        $response3 = $this->post(route('users.get_user_info'), $data2);
+        $response3->assertOk();
+
+        // チェックしていなくてチェックを外そうとする
+        $response4 = $this->post(route('users.get_user_info'), $data2);
+        $response4->assertOk();
+
+        // 投票後
+        // まだチェックしてなくてチェックしようとする
+        $response5 = $this->post(route('users.get_user_info'), $data1);
+        $response5->assertOk();
+
+        // チェックしていて外そうとする
+        $response6 = $this->post(route('users.get_user_info'), $data1);
+        $response6->assertOk();
+
+        // チェックしていてチェックしようとする
+        $response7 = $this->post(route('users.get_user_info'), $data2);
+        $response7->assertOk();
+        
+        // チェックしていなくてチェックを外そうとする
+        $response8 = $this->post(route('users.get_user_info'), $data2);
+        $respons8->assertOk();
+    }
+}

--- a/tests/Feature/VoteControllerTest.php
+++ b/tests/Feature/VoteControllerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class UserControllerTest extends TestCase
+{
+    use DatabaseTransactions;
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function test_get_winner()
+    {
+        // インサートするテーブルをこっちで決めればいいのか
+        // テーブルだけ作っておいてシーディングをここからする
+        
+        // ログインする
+        
+        
+        
+        // ログイン情報を利用してgetリクエスト飛ばす
+        $response = $this->get(route('users.get_winner'));
+        // レスポンスの検証
+        // 勝者が存在するとき
+        $response->assertOk() # ステータスコードが 200
+            ->assertJsonCount(1) # レスポンスの配列の件数がtasksテーブルのレコード数
+            // レスポンスで返ってきたものが全て一致する
+            ->assertJsonFragment([ # レスポンスJSON に以下の値を含む
+                'name' => '', // ここでシーディングしていれば答えの人間と数字を決め打ちできる
+                'voting_number' => '', // ここでシーディングしていれば答えの人間と数字を決め打ちできる
+            ]);
+
+        // 勝者が存在しないとき
+        $response->assertOk() # ステータスコードが 200
+            ->assertJsonCount(1) # レスポンスの配列の件数がtasksテーブルのレコード数
+            // レスポンスで返ってきたものが全て一致する
+            ->assertJsonFragment([ # レスポンスJSON に以下の値を含む
+                'name' => '', // ここでシーディングしていれば答えの人間と数字を決め打ちできる
+                'voting_number' => '', // ここでシーディングしていれば答えの人間と数字を決め打ちできる
+            ]);
+
+        // 回答を確認する権限がないとき
+        $response->assertOk(); # ステータスコードが 200
+    }
+
+    public function post_completed_task()
+    {
+        
+        // ログインする
+        
+        // ログイン情報を利用してgetリクエスト飛ばす
+
+        $data1 = [ # 登録用のデータ
+            'task_id' => 1,
+            'is_task_checked' => FALSE
+        ];
+        
+        $data2 = [ # 登録用のデータ
+            'task_id' => 1,
+            'is_task_checked' => TRUE
+        ];
+
+
+        // 投票する前
+        // まだチェックしてなくてチェックしようとする
+        $response1 = $this->post(route('users.get_user_info'), $data1);
+        $response1->assertOk();
+
+        // チェックしていてチェックしようとする
+        $response2 = $this->post(route('users.get_user_info'), $data1);
+        $response2->assertOk();
+        
+        // チェックしていて外そうとする
+        $response3 = $this->post(route('users.get_user_info'), $data2);
+        $response3->assertOk();
+
+        // チェックしていなくてチェックを外そうとする
+        $response4 = $this->post(route('users.get_user_info'), $data2);
+        $response4->assertOk();
+
+        // 投票後
+        // まだチェックしてなくてチェックしようとする
+        $response5 = $this->post(route('users.get_user_info'), $data1);
+        $response5->assertOk();
+
+        // チェックしていて外そうとする
+        $response6 = $this->post(route('users.get_user_info'), $data1);
+        $response6->assertOk();
+
+        // チェックしていてチェックしようとする
+        $response7 = $this->post(route('users.get_user_info'), $data2);
+        $response7->assertOk();
+        
+        // チェックしていなくてチェックを外そうとする
+        $response8 = $this->post(route('users.get_user_info'), $data2);
+        $respons8->assertOk();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,9 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+    public function setUp(): void
+    {
+        // ここでマイグレーションとシーディングをする
+    }
+
 }

--- a/tests/apiTest.http
+++ b/tests/apiTest.http
@@ -104,15 +104,15 @@ Authorization: Bearer 9|JbccOViIXo1YA4Fvo83EoNM5Q01YDpPpOqCif62W
 
 # タスクの更新
 ###
-POST http://localhost/api/task HTTP/1.1
+PUT http://localhost/api/task HTTP/1.1
 content-type: application/json
 Authorization: Bearer 9|JbccOViIXo1YA4Fvo83EoNM5Q01YDpPpOqCif62W
 
 {
-    "id":7,
-    "name": "update2",
-    "grade_id": 1,
-    "genre_id": 1,
-    "description": "updated this description2"
+    "id":6,
+    "name": "update3",
+    "grade_id": 2,
+    "genre_id": 2,
+    "description": "updated this description3"
 }
 ###

--- a/tests/apiTest.http
+++ b/tests/apiTest.http
@@ -20,8 +20,8 @@ POST http://localhost/api/login HTTP/1.1
 content-type: application/json
 
 {
-    "email" : "gen@co.jp",
-    "password": "word"
+    "email" : "adm@co.jp",
+    "password": "pass"
 }
 ###
 
@@ -84,5 +84,35 @@ Authorization: Bearer 3|xseypxVWRYw4rPup7jvRv5XgaSMFyhDwioFCe87n
 
 {
     "voting_number": 100
+}
+###
+
+# タスクを追加する
+###
+POST http://localhost/api/task HTTP/1.1
+content-type: application/json
+Authorization: Bearer 9|JbccOViIXo1YA4Fvo83EoNM5Q01YDpPpOqCif62W
+
+{
+    "name": "$request->name",
+    "grade_id": 1,
+    "genre_id": 1,
+    "description": "$request->description",
+    "is_positive_check": true
+}
+###
+
+# タスクの更新
+###
+POST http://localhost/api/task HTTP/1.1
+content-type: application/json
+Authorization: Bearer 9|JbccOViIXo1YA4Fvo83EoNM5Q01YDpPpOqCif62W
+
+{
+    "id":7,
+    "name": "update2",
+    "grade_id": 1,
+    "genre_id": 1,
+    "description": "updated this description2"
 }
 ###


### PR DESCRIPTION
## チケットへのリンク

#14 

## やったこと

`api/task`に`POST`,`PUT`の二つのメソッドを追加した
`POST`: 管理者が新タスクを追加する
- リクエストボディは `name`,`grade_id`,`genre_id`,`description`,`is_positive_check`が必要十分

`PUT`: 管理者がタスクの内容を更新する
- リクエストボディは `name`,`grade_id`,`genre_id`,`description`,`is_positive_check` が必要十分

## やらないこと

なし

## できるようになること（ユーザ目線）

管理者が新規タスクを登録できるようになる
管理者が既存タスクを変更できるようになる

## できなくなること（ユーザ目線）

なし

## 動作確認

手動で確認

## その他

サービスへの切り出しは後でやります